### PR TITLE
small fixes

### DIFF
--- a/utils/calc_spring_transition.py
+++ b/utils/calc_spring_transition.py
@@ -153,9 +153,9 @@ def calc_spring_transition_timing_magnitude(flow_matrix, class_number, summer_ti
                 timings[-1] = timings[-1] - 4 + new_timings + lag_time
                 magnitudes[-1] = max_flow_window_new
             
-            """Fix From Bronwen"""
+            """Fix From Bronwen & Cam"""
             if class_number == 4 or class_number == 6 or class_number == 7 or class_number == 8:
-                magnitudes[-1] = flow_data[timings[-1]] 
+                magnitudes[-1] = flow_data[timings[-1] - 1] 
 
             if summer_timings[column_number] is not None and timings[-1] > summer_timings[column_number]:
                 timings[-1] = None

--- a/utils/calc_summer_baseflow.py
+++ b/utils/calc_summer_baseflow.py
@@ -24,10 +24,10 @@ def calc_start_of_summer(matrix, class_number, summer_params=def_summer_params):
         if get_max_consecutive_nan(matrix[:, column_number]) > max_consecutive_nan_allowed_per_year:
             continue
         
-        """Append each column with 30 more days from next column, except the last column"""
+        """Append each column with 100 more days from next column, except the last column"""
         if column_number != len(matrix[0])-1:
             flow_data = list(matrix[:, column_number]) + \
-                list(matrix[:30, column_number+1])
+                list(matrix[:100, column_number+1])
         else:
             flow_data = matrix[:, column_number]
 


### PR DESCRIPTION
tiny adjustments, the addition of  `- 1` in `utils/calc_spring_transition.py` is to address the fact that the arrays were not both indexed from 1. The change in `utils/calc_summer_baseflow.py` is to revert a change that was having some cascading effects and to match the old calculator (which did 100 days before)