### PR TITLE
remove alteration type on insufficient_data

### DIFF
--- a/utils/alteration_assessment.py
+++ b/utils/alteration_assessment.py
@@ -103,10 +103,17 @@ def compare_data_frames(raw_metrics, predicted_metrics, raw_percentiles, count, 
         'insufficient_data',
         combined_df['status']
     )
+
     combined_df['status_code'] = np.where(
         combined_df['status'] == 'insufficient_data',
         0,
         combined_df['status_code']
+    )
+
+    combined_df['alteration_type'] = np.where(
+        combined_df['status'] == 'insufficient_data',
+        "unknown",
+        combined_df['alteration_type']
     )
 
     combined_df.loc[


### PR DESCRIPTION
Slide 174 of https://docs.google.com/presentation/d/1P89QMF_4_Vwus2ZRM7x5OQwX4leLOiPEzudgh0mFLUE/edit?slide=id.g369aa166e54_0_11#slide=id.g369aa166e54_0_11 To test verify that for the case listed in the slides the alteration type is gone (MCA gage from CDEC)